### PR TITLE
two stage docker build

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -11,7 +11,9 @@ COPY Gemfile Gemfile.lock ./
 RUN gem install bundler:2.1.4 && \
     bundle install
 
-# [stage 2] **************************************************
+#############
+### Stage 2 #
+#############
 FROM ruby:2.6.6-alpine3.12
 
 WORKDIR /usr/src/app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,7 +12,7 @@ RUN gem install bundler:2.1.4 && \
     bundle install
 
 #############
-### Stage 2 #
+## Stage 2 ##
 #############
 FROM ruby:2.6.6-alpine3.12
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,6 @@
-# [stage 1] **************************************************
+#############
+### Stage 1 #
+#############
 FROM ruby:2.6.6-alpine3.12 as gembuilder
 
 RUN apk add --no-cache --update build-base cmake

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 #############
-### Stage 1 #
+## Stage 1 ##
 #############
 FROM ruby:2.6.6-alpine3.12 as gembuilder
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,18 +1,27 @@
-FROM ruby:2.6.6-alpine3.12
+# [stage 1] **************************************************
+FROM ruby:2.6.6-alpine3.12 as gembuilder
 
-RUN gem install bundler && \
-    apk add --no-cache --update build-base cmake git
+# RUN gem install bundler && \
+RUN apk add --no-cache --update build-base cmake
 
-RUN git clone https://github.com/exercism/ruby-test-runner /usr/src/ruby-test-runner && \
-    cd /usr/src/ruby-test-runner && \
-    bundle install
+# RUN git clone https://github.com/exercism/ruby-test-runner /usr/src/ruby-test-runner && \
+#     cd /usr/src/ruby-test-runner && \
+#     bundle install
 
 WORKDIR /usr/src/app
 
-RUN gem install bundler:2.1.4
 COPY Gemfile Gemfile.lock ./
-RUN bundle install
+RUN gem install bundler:2.1.4 && \
+    bundle install
 
-ENTRYPOINT bundle update --full-index --conservative exercism_config && \
-           EXERCISM_DOCKER=true EXERCISM_ENV=development bundle exec setup_exercism_config && \
-           ./bin/worker
+# [stage 2] **************************************************
+FROM ruby:2.6.6-alpine3.12
+
+WORKDIR /usr/src/app
+
+COPY Gemfile Gemfile.lock ./
+RUN gem install bundler:2.1.4
+
+COPY --from=gembuilder /usr/local/bundle/ /usr/local/bundle/
+
+ENTRYPOINT ./bin/worker

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,12 +1,7 @@
 # [stage 1] **************************************************
 FROM ruby:2.6.6-alpine3.12 as gembuilder
 
-# RUN gem install bundler && \
 RUN apk add --no-cache --update build-base cmake
-
-# RUN git clone https://github.com/exercism/ruby-test-runner /usr/src/ruby-test-runner && \
-#     cd /usr/src/ruby-test-runner && \
-#     bundle install
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
- avoids build-base being in the final image
- builds gems in builder image than copies over binaries to the final image
- removes Ruby test runner, why???
- remove running `setup_exercism_config`, this should be centralized See: https://github.com/exercism/v3-docker-compose/pull/7
- as a result no need to run `bundle` constantly either
- reduces Docker image size from 350mb to 72mb