### PR TITLE
Fix docker build

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -4,7 +4,7 @@
 FROM exercism/setup as common
 FROM ruby:2.6.6-alpine3.12 as gembuilder
 
-RUN apk add --no-cache --update build-base cmake
+RUN apk add --no-cache --update build-base cmake openssl-dev
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
There was an issue with the Docker build due to `bundle install` failing. See https://github.com/exercism/tooling-invoker/actions/runs/502089600

It turned out that no OpenSSL library could be found. This PR fixes that.