### PR TITLE
Allow more memory to clojurescript test runner

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -14,5 +14,9 @@
   "ruby_test_runner": {
     "network": "none",
     "max_memory": "1GB"
+  },
+  "clojurescript_test_runner": {
+    "network": "none",
+    "max_memory": "3GB"
   }
 }


### PR DESCRIPTION
With the increased memory, the clojurescript test runner is able to finish on my local development environment. Without it, there is a timeout. I'll also create an issue to improve the performance.
