### PR TITLE
Add resiliency to job processing failures

### DIFF
--- a/lib/tooling_invoker/process_job.rb
+++ b/lib/tooling_invoker/process_job.rb
@@ -16,10 +16,12 @@ module ToolingInvoker
     attr_reader :job
 
     def prepare_input!
-      Log.("Preparing input", job: job)
-      FileUtils.mkdir_p(job.dir)
+      Log.("Preparing input", job: job)      
+      FileUtils.mkdir_p(job.dir)      
       FileUtils.mkdir(job.source_code_dir)
       FileUtils.mkdir(job.output_dir)
+
+      FileUtils.rm_rf("#{job.dir}/*")
 
       SetupInputFiles.(job)
 

--- a/lib/tooling_invoker/process_job.rb
+++ b/lib/tooling_invoker/process_job.rb
@@ -55,7 +55,7 @@ module ToolingInvoker
     end
 
     RETRY_SLEEP_SECONDS = [0.1, 0.3, 0.6].freeze
-    MAX_NUM_RETRIES = 3
+    MAX_NUM_RETRIES = RETRY_SLEEP_SECONDS.length
 
     private_constant :RETRY_SLEEP_SECONDS, :MAX_NUM_RETRIES
   end

--- a/lib/tooling_invoker/process_job.rb
+++ b/lib/tooling_invoker/process_job.rb
@@ -54,7 +54,7 @@ module ToolingInvoker
       job.exceptioned!(e.message, backtrace: e.backtrace)
     end
 
-    RETRY_SLEEP_SECONDS = [0.1, 0.3, 0.6].freeze
+    RETRY_SLEEP_SECONDS = [0.1, 0.2, 0.5, 1.0].freeze
     MAX_NUM_RETRIES = RETRY_SLEEP_SECONDS.length
 
     private_constant :RETRY_SLEEP_SECONDS, :MAX_NUM_RETRIES

--- a/test/process_job_test.rb
+++ b/test/process_job_test.rb
@@ -65,18 +65,12 @@ module ToolingInvoker
       begin
         ExecDocker.any_instance.stubs(docker_run_command: "#{__dir__}/bin/mock_docker")
 
-        # To simulate SetupInputFiles working as expected after three calls,
-        # we cheat and execute it beforehand. The first three calls to it will
-        # still raise (see code below), but the fourth with just finish immediately
-        # and it will look like it finishes as normal.
-        ToolingInvoker::SetupInputFiles.(job)
-        
-        ToolingInvoker::SetupInputFiles.expects(:call)
-          .times(4)
-          .raises(StandardError)
-          .then.raises(StandardError)
-          .then.raises(StandardError)
-          .then.returns(true)
+        ToolingInvoker::SetupInputFiles.expects(:call).
+          times(4).
+          raises(StandardError).
+          then.raises(StandardError).
+          then.raises(StandardError).
+          then.returns(true)
 
         FileUtils.mkdir_p(job.dir)
         Dir.chdir(job.dir) do
@@ -105,13 +99,13 @@ module ToolingInvoker
 
       begin
         ExecDocker.any_instance.stubs(docker_run_command: "#{__dir__}/bin/mock_docker")
-        
-        ToolingInvoker::SetupInputFiles.expects(:call)
-          .times(4)
-          .raises(StandardError)
-          .then.raises(StandardError)
-          .then.raises(StandardError)
-          .then.raises(StandardError)
+
+        ToolingInvoker::SetupInputFiles.expects(:call).
+          times(4).
+          raises(StandardError).
+          then.raises(StandardError).
+          then.raises(StandardError).
+          then.raises(StandardError)
 
         FileUtils.mkdir_p(job.dir)
         Dir.chdir(job.dir) do
@@ -137,22 +131,22 @@ module ToolingInvoker
 
       begin
         ExecDocker.any_instance.stubs(docker_run_command: "#{__dir__}/bin/mock_docker")
-        
-        ToolingInvoker::SetupInputFiles.expects(:call)
-          .times(4)
-          .raises(StandardError)
-          .then.raises(StandardError)
-          .then.raises(StandardError)
-          .then.raises(StandardError)
+
+        ToolingInvoker::SetupInputFiles.expects(:call).
+          times(4).
+          raises(StandardError).
+          then.raises(StandardError).
+          then.raises(StandardError).
+          then.raises(StandardError)
 
         FileUtils.mkdir_p(job.dir)
 
         start = Time.now
-        Dir.chdir(job.dir) do          
-          ProcessJob.(job)          
+        Dir.chdir(job.dir) do
+          ProcessJob.(job)
         end
         elapsed = Time.now - start
-        
+
         assert elapsed < 2
       ensure
         FileUtils.rm_rf(job.dir)

--- a/test/process_job_test.rb
+++ b/test/process_job_test.rb
@@ -66,8 +66,9 @@ module ToolingInvoker
         ExecDocker.any_instance.stubs(docker_run_command: "#{__dir__}/bin/mock_docker")
 
         ToolingInvoker::SetupInputFiles.expects(:call).
-          times(4).
+          times(5).
           raises(StandardError).
+          then.raises(StandardError).
           then.raises(StandardError).
           then.raises(StandardError).
           then.returns(true)
@@ -101,8 +102,9 @@ module ToolingInvoker
         ExecDocker.any_instance.stubs(docker_run_command: "#{__dir__}/bin/mock_docker")
 
         ToolingInvoker::SetupInputFiles.expects(:call).
-          times(4).
+          times(5).
           raises(StandardError).
+          then.raises(StandardError).
           then.raises(StandardError).
           then.raises(StandardError).
           then.raises(StandardError)
@@ -133,8 +135,9 @@ module ToolingInvoker
         ExecDocker.any_instance.stubs(docker_run_command: "#{__dir__}/bin/mock_docker")
 
         ToolingInvoker::SetupInputFiles.expects(:call).
-          times(4).
+          times(5).
           raises(StandardError).
+          then.raises(StandardError).
           then.raises(StandardError).
           then.raises(StandardError).
           then.raises(StandardError)
@@ -147,7 +150,7 @@ module ToolingInvoker
         end
         elapsed = Time.now - start
 
-        assert elapsed < 2
+        assert elapsed <= 2
       ensure
         FileUtils.rm_rf(job.dir)
       end

--- a/test/process_job_test.rb
+++ b/test/process_job_test.rb
@@ -53,6 +53,112 @@ module ToolingInvoker
       end
     end
 
+    def test_failed_setup_retried_thrice
+      job = Jobs::TestRunnerJob.new(
+        SecureRandom.hex,
+        "ruby",
+        "bob",
+        { 'submission_filepaths' => [] },
+        "v1"
+      )
+
+      begin
+        ExecDocker.any_instance.stubs(docker_run_command: "#{__dir__}/bin/mock_docker")
+
+        # To simulate SetupInputFiles working as expected after three calls,
+        # we cheat and execute it beforehand. The first three calls to it will
+        # still raise (see code below), but the fourth with just finish immediately
+        # and it will look like it finishes as normal.
+        ToolingInvoker::SetupInputFiles.(job)
+        
+        ToolingInvoker::SetupInputFiles.expects(:call)
+          .times(4)
+          .raises(StandardError)
+          .then.raises(StandardError)
+          .then.raises(StandardError)
+          .then.returns(true)
+
+        FileUtils.mkdir_p(job.dir)
+        Dir.chdir(job.dir) do
+          ProcessJob.(job)
+        end
+
+        expected_output = { "results.json" => '{"happy": "people"}' }
+
+        assert_equal 200, job.status
+        assert_equal expected_output, job.output
+        assert_equal "", job.stdout
+        assert_equal "", job.stderr
+      ensure
+        FileUtils.rm_rf(job.dir)
+      end
+    end
+
+    def test_failed_setup_stops_at_fourth_retry
+      job = Jobs::TestRunnerJob.new(
+        SecureRandom.hex,
+        "ruby",
+        "bob",
+        { 'submission_filepaths' => [] },
+        "v1"
+      )
+
+      begin
+        ExecDocker.any_instance.stubs(docker_run_command: "#{__dir__}/bin/mock_docker")
+        
+        ToolingInvoker::SetupInputFiles.expects(:call)
+          .times(4)
+          .raises(StandardError)
+          .then.raises(StandardError)
+          .then.raises(StandardError)
+          .then.raises(StandardError)
+
+        FileUtils.mkdir_p(job.dir)
+        Dir.chdir(job.dir) do
+          ProcessJob.(job)
+        end
+
+        assert_equal 512, job.status
+        assert_equal "", job.stdout
+        assert_equal "", job.stderr
+      ensure
+        FileUtils.rm_rf(job.dir)
+      end
+    end
+
+    def test_failed_setup_retries_doesnt_wait_longer_than_two_seconds
+      job = Jobs::TestRunnerJob.new(
+        SecureRandom.hex,
+        "ruby",
+        "bob",
+        { 'submission_filepaths' => [] },
+        "v1"
+      )
+
+      begin
+        ExecDocker.any_instance.stubs(docker_run_command: "#{__dir__}/bin/mock_docker")
+        
+        ToolingInvoker::SetupInputFiles.expects(:call)
+          .times(4)
+          .raises(StandardError)
+          .then.raises(StandardError)
+          .then.raises(StandardError)
+          .then.raises(StandardError)
+
+        FileUtils.mkdir_p(job.dir)
+
+        start = Time.now
+        Dir.chdir(job.dir) do          
+          ProcessJob.(job)          
+        end
+        elapsed = Time.now - start
+        
+        assert elapsed < 2
+      ensure
+        FileUtils.rm_rf(job.dir)
+      end
+    end
+
     def test_failed_invocation
       job = Jobs::TestRunnerJob.new(
         SecureRandom.hex,


### PR DESCRIPTION
- Remove job dir first when preparing input
- Add three retries when processing job
- Sleep between retries of job processing failures
