### PR TITLE
Allow for optional output files

### DIFF
--- a/lib/tooling_invoker/jobs/analyzer_job.rb
+++ b/lib/tooling_invoker/jobs/analyzer_job.rb
@@ -3,7 +3,7 @@ module ToolingInvoker::Jobs
     def type = "analyzer"
     def cmd = "bin/run.sh"
     def invocation_args = [exercise, "/mnt/exercism-iteration/", "/mnt/exercism-iteration/"]
-    def output_filepaths = ["analysis.json"]
+    def required_filepaths = ["analysis.json"]
     def optional_filepaths = []
     def working_directory = "/opt/analyzer"
     def tool = "#{language}-analyzer"

--- a/lib/tooling_invoker/jobs/analyzer_job.rb
+++ b/lib/tooling_invoker/jobs/analyzer_job.rb
@@ -4,6 +4,7 @@ module ToolingInvoker::Jobs
     def cmd = "bin/run.sh"
     def invocation_args = [exercise, "/mnt/exercism-iteration/", "/mnt/exercism-iteration/"]
     def output_filepaths = ["analysis.json"]
+    def optional_filepaths = []
     def working_directory = "/opt/analyzer"
     def tool = "#{language}-analyzer"
   end

--- a/lib/tooling_invoker/jobs/job.rb
+++ b/lib/tooling_invoker/jobs/job.rb
@@ -117,7 +117,7 @@ module ToolingInvoker
       end
 
       def valid_output?
-        required_output_filepaths.all? do |output_filepath|
+        required_filepaths.all? do |output_filepath|
           contents = File.read("#{source_code_dir}/#{output_filepath}")
           contents && contents.size > 0 && contents.size <= MAX_OUTPUT_FILE_SIZE
         rescue StandardError
@@ -125,7 +125,7 @@ module ToolingInvoker
         end
       end
 
-      def required_output_filepaths = output_filepaths - optional_filepaths
+      def output_filepaths = required_filepaths + optional_filepaths
 
       def image
         "#{Configuration.instance.image_registry}/#{tool}:#{Configuration.instance.image_tag}"

--- a/lib/tooling_invoker/jobs/job.rb
+++ b/lib/tooling_invoker/jobs/job.rb
@@ -117,13 +117,15 @@ module ToolingInvoker
       end
 
       def valid_output?
-        output_filepaths.all? do |output_filepath|
+        required_output_filepaths.all? do |output_filepath|
           contents = File.read("#{source_code_dir}/#{output_filepath}")
           contents && contents.size > 0 && contents.size <= MAX_OUTPUT_FILE_SIZE
         rescue StandardError
           false
         end
       end
+
+      def required_output_filepaths = output_filepaths - optional_filepaths
 
       def image
         "#{Configuration.instance.image_registry}/#{tool}:#{Configuration.instance.image_tag}"

--- a/lib/tooling_invoker/jobs/representer_job.rb
+++ b/lib/tooling_invoker/jobs/representer_job.rb
@@ -3,7 +3,7 @@ module ToolingInvoker::Jobs
     def type = "representer"
     def cmd = "bin/run.sh"
     def invocation_args = [exercise, "/mnt/exercism-iteration/", "/mnt/exercism-iteration/"]
-    def output_filepaths = ["representation.txt", "representation.json", "mapping.json"]
+    def required_filepaths = ["representation.txt", "mapping.json"]
     def optional_filepaths = ["representation.json"]
     def working_directory = "/opt/representer"
     def tool = "#{language}-representer"

--- a/lib/tooling_invoker/jobs/representer_job.rb
+++ b/lib/tooling_invoker/jobs/representer_job.rb
@@ -4,6 +4,7 @@ module ToolingInvoker::Jobs
     def cmd = "bin/run.sh"
     def invocation_args = [exercise, "/mnt/exercism-iteration/", "/mnt/exercism-iteration/"]
     def output_filepaths = ["representation.txt", "representation.json", "mapping.json"]
+    def optional_filepaths = ["representation.json"]
     def working_directory = "/opt/representer"
     def tool = "#{language}-representer"
   end

--- a/lib/tooling_invoker/jobs/test_runner_job.rb
+++ b/lib/tooling_invoker/jobs/test_runner_job.rb
@@ -4,7 +4,7 @@ module ToolingInvoker
       def type = "test-runner"
       def cmd = "bin/run.sh"
       def invocation_args = [exercise, "/mnt/exercism-iteration/", "/mnt/exercism-iteration/"]
-      def output_filepaths = ["results.json"]
+      def required_filepaths = ["results.json"]
       def optional_filepaths = []
       def working_directory = "/opt/test-runner"
     end

--- a/lib/tooling_invoker/jobs/test_runner_job.rb
+++ b/lib/tooling_invoker/jobs/test_runner_job.rb
@@ -5,6 +5,7 @@ module ToolingInvoker
       def cmd = "bin/run.sh"
       def invocation_args = [exercise, "/mnt/exercism-iteration/", "/mnt/exercism-iteration/"]
       def output_filepaths = ["results.json"]
+      def optional_filepaths = []
       def working_directory = "/opt/test-runner"
     end
   end

--- a/test/job_processor/process_test.rb
+++ b/test/job_processor/process_test.rb
@@ -239,7 +239,7 @@ module ToolingInvoker
         # Note: we're missing the representation.json file
         FileUtils.mkdir_p(job.source_code_dir)
         File.write("#{job.source_code_dir}/#{job.output_filepaths[0]}", representation)
-        File.write("#{job.source_code_dir}/#{job.output_filepaths[2]}", mapping)
+        File.write("#{job.source_code_dir}/#{job.output_filepaths[1]}", mapping)
 
         begin
           ExecDocker.any_instance.stubs(docker_run_command: "#{__dir__}/../bin/infinite_loop")

--- a/test/jobs/analyzer_job_test.rb
+++ b/test/jobs/analyzer_job_test.rb
@@ -25,6 +25,7 @@ module ToolingInvoker::Jobs
         "/mnt/exercism-iteration/"
       ], job.invocation_args
       assert_equal ["analysis.json"], job.output_filepaths
+      assert_equal ["analysis.json"], job.required_filepaths
       assert_empty job.optional_filepaths
       assert_equal "/opt/analyzer", job.working_directory
     end

--- a/test/jobs/analyzer_job_test.rb
+++ b/test/jobs/analyzer_job_test.rb
@@ -25,6 +25,7 @@ module ToolingInvoker::Jobs
         "/mnt/exercism-iteration/"
       ], job.invocation_args
       assert_equal ["analysis.json"], job.output_filepaths
+      assert_empty job.optional_filepaths
       assert_equal "/opt/analyzer", job.working_directory
     end
   end

--- a/test/jobs/representer_job_test.rb
+++ b/test/jobs/representer_job_test.rb
@@ -24,6 +24,7 @@ module ToolingInvoker::Jobs
         "/mnt/exercism-iteration/"
       ], job.invocation_args
       assert_equal ["representation.txt", "representation.json", "mapping.json"], job.output_filepaths
+      assert_equal ["representation.json"], job.optional_filepaths
       assert_equal "/opt/representer", job.working_directory
     end
   end

--- a/test/jobs/representer_job_test.rb
+++ b/test/jobs/representer_job_test.rb
@@ -23,7 +23,8 @@ module ToolingInvoker::Jobs
         "/mnt/exercism-iteration/",
         "/mnt/exercism-iteration/"
       ], job.invocation_args
-      assert_equal ["representation.txt", "representation.json", "mapping.json"], job.output_filepaths
+      assert_equal ["representation.txt", "mapping.json", "representation.json"], job.output_filepaths
+      assert_equal ["representation.txt", "mapping.json"], job.required_filepaths
       assert_equal ["representation.json"], job.optional_filepaths
       assert_equal "/opt/representer", job.working_directory
     end

--- a/test/jobs/test_runner_job_test.rb
+++ b/test/jobs/test_runner_job_test.rb
@@ -24,6 +24,7 @@ module ToolingInvoker::Jobs
         "/mnt/exercism-iteration/"
       ], job.invocation_args
       assert_equal ["results.json"], job.output_filepaths
+      assert_equal ["results.json"], job.required_filepaths
       assert_empty job.optional_filepaths
       assert_equal "/opt/test-runner", job.working_directory
     end

--- a/test/jobs/test_runner_job_test.rb
+++ b/test/jobs/test_runner_job_test.rb
@@ -24,6 +24,7 @@ module ToolingInvoker::Jobs
         "/mnt/exercism-iteration/"
       ], job.invocation_args
       assert_equal ["results.json"], job.output_filepaths
+      assert_empty job.optional_filepaths
       assert_equal "/opt/test-runner", job.working_directory
     end
   end


### PR DESCRIPTION
This is needed to add the new `tags.json` file. I've created this as a separate PR as I found that the `representation.json` is only output by a couple of representers (and not by, for example, the Elixir or Python representer)