### PR TITLE
Increase Go test runner timeout to 30 seconds

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -35,5 +35,8 @@
   },
   "batch_test_runner": {
     "network": "internal"
+  },
+  "go_test_runner": {
+    "timeout": 30
   }
 }


### PR DESCRIPTION
While the Go test runner is usually very fast, some exercises benefit from running the tests with the race detector enabled. This can increase significantly the time tests take to run, and this increase in timeout is aimed at those exercises.

Currently, exercises with the race detector enabled are having timeouts regularly, while sometimes they pass. Adding 10 seconds to the default timeout of 20 seconds should make those tests pass more consistently.

For more context, see: http://forum.exercism.org/t/bank-account-potential-bug/8326/14
Also reported in the test runner repo: https://github.com/exercism/go-test-runner/issues/111